### PR TITLE
Add GraphQL query agent

### DIFF
--- a/grid_agentic_ai/agents/__init__.py
+++ b/grid_agentic_ai/agents/__init__.py
@@ -4,3 +4,4 @@ from .query_parser import QueryParserAgent
 
 from .summarizer import SummarizerAgent
 from .output_generator import OutputGeneratorAgent
+from .graphql_query_agent import GraphQLQueryAgent, generate_query

--- a/grid_agentic_ai/agents/graphql_query_agent.py
+++ b/grid_agentic_ai/agents/graphql_query_agent.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+"""GraphQL query generation agent using LlamaIndex and Ollama."""
+
+from typing import Optional
+
+try:
+    from llama_index.core import Document, VectorStoreIndex
+except Exception:  # pragma: no cover - optional dependency
+    Document = None  # type: ignore
+    VectorStoreIndex = None  # type: ignore
+
+try:
+    import ollama  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    ollama = None  # type: ignore
+
+
+class GraphQLQueryAgent:
+    """Load a GraphQL schema and generate queries for natural language questions."""
+
+    def __init__(self, schema_path: str) -> None:
+        self.schema_path = schema_path
+        self._index = None
+        self._schema_text = ""
+        self._load_schema()
+
+    def _load_schema(self) -> None:
+        try:
+            with open(self.schema_path, "r", encoding="utf-8") as fh:
+                self._schema_text = fh.read()
+        except Exception:
+            self._schema_text = ""
+
+        if Document is None or VectorStoreIndex is None:
+            return
+        try:
+            docs = [Document(text=self._schema_text)]
+            self._index = VectorStoreIndex.from_documents(docs)
+        except Exception:
+            self._index = None
+
+    def _retrieve_context(self, question: str) -> str:
+        if self._index is None:
+            return self._schema_text
+        try:
+            engine = self._index.as_query_engine(similarity_top_k=3)
+            result = engine.query(question)
+            return str(result)
+        except Exception:
+            return self._schema_text
+
+    def generate(self, question: str) -> str:
+        context = self._retrieve_context(question)
+        prompt = (
+            "You are a helpful assistant that writes GraphQL queries.\n"
+            f"Schema:\n{context}\n"
+            f"Question: {question}\n"
+            "Return only the GraphQL query." 
+        )
+        if ollama is None:
+            return ""
+        try:
+            response = ollama.chat(
+                model="llama3",
+                messages=[{"role": "user", "content": prompt}],
+            )
+            if isinstance(response, dict):
+                message = response.get("message", {})
+                return str(message.get("content", "")).strip()
+            return str(response).strip()
+        except Exception:
+            return ""
+
+
+def generate_query(question: str, schema_path: str) -> str:
+    """Convenience wrapper to generate a GraphQL query from ``question``."""
+    agent = GraphQLQueryAgent(schema_path)
+    return agent.generate(question)

--- a/grid_agentic_ai/docs/AGENTS.md
+++ b/grid_agentic_ai/docs/AGENTS.md
@@ -88,3 +88,15 @@ This document describes the public interface for each core agent in this reposit
   out = OutputGeneratorAgent()
   out.to_csv(results, "out.csv")
   ```
+
+## GraphQLQueryAgent
+
+- **Location:** `grid_agentic_ai/agents/graphql_query_agent.py`
+- **Class:** `GraphQLQueryAgent`
+- **Public Function:** `generate_query(question: str, schema_path: str) -> str`
+- **Description:** Load a GraphQL schema, index it with LlamaIndex and use a local Ollama model to generate GraphQL queries from natural language questions.
+- **Example:**
+  ```python
+  from grid_agentic_ai.agents.graphql_query_agent import generate_query
+  query = generate_query("List drug names", "schema.graphql")
+  ```

--- a/grid_agentic_ai/tests/test_graphql_query_agent.py
+++ b/grid_agentic_ai/tests/test_graphql_query_agent.py
@@ -1,0 +1,61 @@
+import os
+import sys
+import types
+from importlib import reload
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from grid_agentic_ai.agents import graphql_query_agent as gqa
+
+
+def setup_fake_llama(monkeypatch):
+    fake_pkg = types.ModuleType('llama_index')
+    fake_core = types.ModuleType('llama_index.core')
+
+    class FakeIndex:
+        def __init__(self, docs):
+            self.docs = docs
+        def as_query_engine(self, similarity_top_k=3):
+            class Engine:
+                def query(self_inner, q):
+                    return 'schema context'
+            return Engine()
+
+    fake_core.Document = lambda text: {'text': text}
+    fake_core.VectorStoreIndex = types.SimpleNamespace(from_documents=lambda docs: FakeIndex(docs))
+    fake_pkg.core = fake_core
+    monkeypatch.setitem(sys.modules, 'llama_index', fake_pkg)
+    monkeypatch.setitem(sys.modules, 'llama_index.core', fake_core)
+
+
+def setup_fake_ollama(monkeypatch):
+    fake = types.ModuleType('ollama')
+    def fake_chat(model=None, messages=None):
+        return {'message': {'content': 'query { id }'}}
+    fake.chat = fake_chat
+    monkeypatch.setitem(sys.modules, 'ollama', fake)
+
+
+def test_generate_query(monkeypatch, tmp_path):
+    setup_fake_llama(monkeypatch)
+    setup_fake_ollama(monkeypatch)
+    reload(gqa)
+
+    schema_file = tmp_path / 'schema.graphql'
+    schema_file.write_text('type Query { id: ID }')
+
+    result = gqa.generate_query('Get id', str(schema_file))
+    assert 'query' in result
+
+
+def test_generate_query_no_deps(monkeypatch, tmp_path):
+    monkeypatch.setitem(sys.modules, 'llama_index', None)
+    monkeypatch.setitem(sys.modules, 'llama_index.core', None)
+    monkeypatch.setitem(sys.modules, 'ollama', None)
+    reload(gqa)
+
+    schema_file = tmp_path / 'schema.graphql'
+    schema_file.write_text('type Query { id: ID }')
+
+    result = gqa.generate_query('Get id', str(schema_file))
+    assert result == ''

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ networkx
 matplotlib
 pytest
 pandas
+llama-index
+ollama


### PR DESCRIPTION
## Summary
- add a GraphQLQueryAgent using LlamaIndex and Ollama
- document it in AGENTS docs
- extend package exports
- update requirements with `llama-index` and `ollama`
- provide unit tests for the new agent

## Testing
- `pytest grid_agentic_ai/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_685018bcde10832da42d0ba906fba7a1